### PR TITLE
Avoid non-existent index error in empty description arrays.

### DIFF
--- a/includes/keel-paypal-donations/keel-paypal-donations-options.php
+++ b/includes/keel-paypal-donations/keel-paypal-donations-options.php
@@ -293,7 +293,7 @@
 					var last = jQuery( '[data-paypal-amount]' ).last();
 					last.closest('tbody').after( '<tr><th>&nbsp;</th><td><p><button class="button js-paypal-add-amount">Add Another Amount</button></p></td></tr>' );
 
-					jQuery( '.js-paypal-add-amount' ).click(function() {
+					jQuery( '.js-paypal-add-amount' ).click(function( event ) {
 
 						// Variables
 						var last = jQuery( '[data-paypal-amount]' ).last();

--- a/includes/keel-paypal-donations/keel-paypal-donations.php
+++ b/includes/keel-paypal-donations/keel-paypal-donations.php
@@ -149,13 +149,12 @@ class Keel_PayPal_Donations {
 		$show_recurring = $options['show_recurring'] === 'on';
 
 		if ( empty( $options['email'] ) || empty( $options['amounts'][0]['amount'] ) || empty( $options['amounts'][0]['description'] ) ) return $table;
-
 		foreach ($options['amounts'] as $key => $amount) {
 			$table_body .=
 				'<tr>' .
-					'<td>' .
-						'<label>' .
-							'<input type="radio" name="paypal_donations_form_amount" id="paypal_donations_form_amount_' . $key . '" value="' . $amount['amount'] . '" ' . checked( $options['default_amount'], $key ) . '> ' .
+					'<td>' . 
+						'<label>' . 
+							'<input type="radio" name="paypal_donations_form_amount" id="paypal_donations_form_amount_' . $key . '" value="' . $amount['amount'] . '" ' . checked( $options['default_amount'], $key, False ) . '> ' .
 							$options['currency'] . $amount['amount'] .
 						'</label>' .
 					'</td>' .

--- a/includes/keel-pet-listings/keel-pet-listings-petfinder.php
+++ b/includes/keel-pet-listings/keel-pet-listings-petfinder.php
@@ -138,7 +138,8 @@
 
 		// Sanitize description and add links
 		if ( $type === 'description' ) {
-			$attribute = keel_petfinder_api_sanitize_description( $pet['description']['$t'] );
+			if (isset($pet['description']['$t']))
+				$attribute = keel_petfinder_api_sanitize_description( $pet['description']['$t'] );
 			$attribute = keel_petfinder_api_linkify( $attribute );
 		}
 


### PR DESCRIPTION
First of all you ROCK for (making and) publishing this. I'm not sure where all `keel_petfinder_api_get_pet_attribute` is being used, but this at least allows it to pull in from our `Shelter ID` which has a bunch of empty descriptions.
