### PR TITLE
Feature to Select Featured pet and display via shortcode

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -219,7 +219,36 @@
 	}
 	add_action( 'init', 'keel_register_menus' );
 
+//Mike iLL
+/**
+ * Register our sidebars and widgetized areas.
+ *
+ */
+function keel_widgets_init() {
 
+register_sidebar( array(
+'name' => 'Footer Widgets',
+'id' => 'keel_footer_1',
+'description' => 'Appears in the footer area',
+'before_widget' => '<aside id="%1$s" class="widget %2$s">',
+'after_widget' => '</aside>',
+'before_title' => '<h3 class="widget-title">',
+'after_title' => '</h3>',
+) );
+
+}
+add_action( 'widgets_init', 'keel_widgets_init' );
+?>
+<?php 
+function keel_footer_widget() {
+	if ( is_active_sidebar( 'keel_footer_1' ) ) : ?>
+		<div id="primary-sidebar" class="primary-sidebar widget-area" role="complementary">
+			<?php dynamic_sidebar( 'keel_footer_1' ); ?>
+		</div><!-- #primary-sidebar -->
+	<?php endif; 
+}
+add_action( 'wp_footer', 'keel_footer_widget' );
+//Mike iLL
 
 	/**
 	 * Adds support for featured post images
@@ -680,6 +709,8 @@
 	require_once( dirname( __FILE__) . '/includes/keel-photoswipe/keel-photoswipe.php' ); // PhotoSwipe.js image galleries
 	require_once( dirname( __FILE__) . '/includes/keel-shortcodes/keel-button-shortcode.php' ); // Button links shortcode
 	require_once( dirname( __FILE__) . '/includes/keel-shortcodes/keel-svg-shortcode.php' ); // Inline SVG shortcode
+	require_once( dirname( __FILE__) . '/includes/keel-shortcodes/keel-featured-pet-shortcode.php' ); // Featured Pet shortcode
+	require_once( dirname( __FILE__) . '/includes/keel-featured-pet.php' ); // Featured Pet
 	require_once( dirname( __FILE__) . '/includes/keel-shortcodes/keel-animal-shelter-manager-forms-shortcode.php' ); // ASM forms shortcode
 	require_once( dirname( __FILE__) . '/includes/keel-set-page-width.php' ); // Custom page widths
 	require_once( dirname( __FILE__) . '/includes/keel-options/keel-theme-support.php' ); // Theme support

--- a/functions.php
+++ b/functions.php
@@ -219,37 +219,6 @@
 	}
 	add_action( 'init', 'keel_register_menus' );
 
-//Mike iLL
-/**
- * Register our sidebars and widgetized areas.
- *
- */
-function keel_widgets_init() {
-
-register_sidebar( array(
-'name' => 'Footer Widgets',
-'id' => 'keel_footer_1',
-'description' => 'Appears in the footer area',
-'before_widget' => '<aside id="%1$s" class="widget %2$s">',
-'after_widget' => '</aside>',
-'before_title' => '<h3 class="widget-title">',
-'after_title' => '</h3>',
-) );
-
-}
-add_action( 'widgets_init', 'keel_widgets_init' );
-?>
-<?php 
-function keel_footer_widget() {
-	if ( is_active_sidebar( 'keel_footer_1' ) ) : ?>
-		<div id="primary-sidebar" class="primary-sidebar widget-area" role="complementary">
-			<?php dynamic_sidebar( 'keel_footer_1' ); ?>
-		</div><!-- #primary-sidebar -->
-	<?php endif; 
-}
-add_action( 'wp_footer', 'keel_footer_widget' );
-//Mike iLL
-
 	/**
 	 * Adds support for featured post images
 	 * @link http://codex.wordpress.org/Post_Thumbnails

--- a/includes/keel-featured-pet.php
+++ b/includes/keel-featured-pet.php
@@ -1,0 +1,170 @@
+<?php
+
+	function keel_featured_pet_settings_field_filters() {
+		$options = keel_featured_pet_get_selections();
+		$pet_names = keel_retrieve_pet_names();
+		$featured_pets = get_option( 'keel_featured_pet_selections' );
+		?>
+		<p class="description"><em>Select a pet to feature.</em></p>
+		<div>
+				<select name="keel_featured_pet_selections[featured_pet]">
+				<?php foreach( $pet_names as $option ) {
+    			echo '<option value="'.$option.'" ';
+    			selected( $featured_pets['featured_pet'], $option );
+    			echo '>'.$option.'</option>';
+				}
+				?>
+				</select>
+		</div>
+		<?php
+	}
+	
+	function keel_featured_pet_backup_settings_field_filters() {
+		$options = keel_featured_pet_get_selections();
+		$pet_names = keel_retrieve_pet_names();
+		$featured_pets = get_option( 'keel_featured_pet_selections' );
+		?>
+		<p class="description"><em>In case first featured pet isn't available.</em></p>
+		<div>
+				<select name="keel_featured_pet_selections[featured_pet_backup]">
+				<?php foreach( $pet_names as $option ) {
+    			echo '<option value="'.$option.'" ';
+    			selected( $featured_pets['featured_pet_backup'], $option );
+    			echo '>'.$option.'</option>';
+				}
+				?>
+				</select>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Return list of names (the post Titles) for each published pet
+	 */
+	function keel_retrieve_pet_names() {
+		$args = array(
+			'posts_per_page' => -1,
+			'post_status' => 'publish',
+			'post_type' => 'keel-pets'
+		);
+		$features = get_posts($args);
+		foreach ( $features as $feature ) :
+
+			$posts[] = $feature->post_title;
+
+		endforeach;
+		return $posts;
+	}
+	
+	/**
+	 * Featured Pet Defaults & Sanitization
+	 * Each option field requires a default value under keel_featured_pet_get_theme_options(), and an if statement under keel_featured_pet_selections_validate();
+	 */
+
+	// Get the current options from the database.
+	// If none are specified, use these defaults.
+	function keel_featured_pet_get_selections() {
+		$saved = (array) get_option( 'keel_featured_pet_selections' );
+
+		$defaults = array(
+			'featured_pet' => '',
+			'featured_pet_backup' => '',
+		);
+
+		$defaults = apply_filters( 'keel_featured_pet_get_selections', $defaults );
+
+		$options = wp_parse_args( $saved, $defaults );
+		$options = array_intersect_key( $options, $defaults );
+
+		return $options;
+	}
+
+	// Sanitize and validate updated featured pet selections - necessary as from select?
+	function keel_featured_pet_validate( $input ) {
+		$output = array();
+
+		if ( isset( $input['featured_pet'] ) && ! empty( $input['featured_pet'] ) )
+			$output['featured_pet'] = wp_filter_nohtml_kses( $input['featured_pet'] );
+
+		if ( isset( $input['featured_pet_backup'] ) && ! empty( $input['featured_pet_backup'] ) )
+			$output['featured_pet_backup'] = wp_filter_nohtml_kses( $input['featured_pet_backup'] );
+
+		return apply_filters( 'keel_featured_pet_validate', $output, $input );
+	}
+
+	/**
+	 * Featured Pet Page
+	 * Each option field requires its own add_settings_field function.
+	 */
+
+	// Create featured pet menu
+	// The content that's rendered on the menu page.
+	function keel_featured_pet_render_page() {
+		$options = keel_featured_pet_get_selections();
+
+		?>
+		<div class="wrap">	
+								
+			<form method="post" action="options.php">
+				<?php
+					settings_fields( 'keel_featured_pet_selections' );
+					do_settings_sections( 'keel_featured_pet_selections' );
+					wp_nonce_field( 'keel_featured_pet_selections_update_options_nonce', 'keel_featured_pet_selections_update_options_process' );
+					submit_button();
+				?>
+			</form>
+			 
+			<h4><?php _e( 'If no featured pet is found, oldest pet will be displayed', 'keel' ); ?></h4>
+
+		</div>
+		<?php
+	}
+
+
+	// Register the featured pet page and its fields
+	function keel_featured_pet_init() {
+
+		// Register a setting and its sanitization callback
+		// register_setting( $option_group, $option_name, $sanitize_callback );
+		// $option_group - A settings group name.
+		// $option_name - The name of an option to sanitize and save.
+		// $sanitize_callback - A callback function that sanitizes the option's value.
+		register_setting( 'keel_featured_pet_selections', 'keel_featured_pet_selections', 'keel_featured_pet_validate' );
+
+
+		// Register our settings field group
+		// add_settings_section( $id, $title, $callback, $page );
+		// $id - Unique identifier for the settings section
+		// $title - Section title
+		// $callback - // Section callback (we don't want anything)
+		// $page - // Menu slug, used to uniquely identify the page. See keel_pet_listings_theme_options_add_page().
+		add_settings_section( 'featured', __( 'Select Featured Pet and display by shortcode [featured-pet]', 'keel' ),  '__return_false', 'keel_featured_pet_selections' );
+
+
+		// Register our individual settings fields
+		// add_settings_field( $id, $title, $callback, $page, $section );
+		// $id - Unique identifier for the field.
+		// $title - Setting field title.
+		// $callback - Function that creates the field (from the Theme Option Fields section).
+		// $page - The menu page on which to display this field.
+		// $section - The section of the settings page in which to show the field.
+		add_settings_field( 'keel_featured_pet', __( 'Featured Pet', 'keel' ), 'keel_featured_pet_settings_field_filters', 'keel_featured_pet_selections', 'featured' );
+		add_settings_field( 'keel_featured_pet_backup', __( 'Backup Featured Pet', 'keel' ), 'keel_featured_pet_backup_settings_field_filters', 'keel_featured_pet_selections', 'featured' );
+	}
+	add_action( 'admin_init', 'keel_featured_pet_init' );
+	// Add the theme options page to the admin menu
+	// Use add_theme_page() to add under Appearance tab (default).
+	// Use add_menu_page() to add as it's own tab.
+	// Use add_submenu_page() to add to another tab.
+	function keel_featured_pet_add_page() {
+
+		// Check that feature is activated
+		$dev_options = keel_developer_options();
+		if ( !$dev_options['pets'] ) return;
+
+		$theme_page = add_submenu_page( 'edit.php?post_type=keel-pets', __( 'Featured Pet', 'keel' ), __( 'Featured Pet', 'keel' ), 'edit_theme_options', 'keel_featured_pet_selections', 'keel_featured_pet_render_page' );
+
+	}
+	add_action( 'admin_menu', 'keel_featured_pet_add_page' );
+
+?>

--- a/includes/keel-shortcodes/keel-featured-pet-shortcode.php
+++ b/includes/keel-shortcodes/keel-featured-pet-shortcode.php
@@ -1,0 +1,152 @@
+<?php
+
+	/**
+	 * Add a shortcode for svg icons
+	 */
+	
+	class Featured_Pet {
+	
+		private static $options;
+		private $featured_pet;
+		private $featured_pet_backup;
+
+		function keel_featured_pet_shortcode( $atts ) {
+
+			$atts = shortcode_atts( array(
+			'type' => 'small'
+				), $atts );
+		$type = $atts['type'];
+
+			global $wp_query, $post;
+			
+			$featured_pets = get_option( 'keel_featured_pet_selections' );
+			
+			$this->featured_pet = $featured_pets['featured_pet'];
+			$this->featured_pet_backup = $featured_pets['featured_pet_backup'];
+
+			$args = array(
+					'posts_per_page' => 1,
+					'search_pet_title' => $this->featured_pet,
+					'post_status' => 'publish',
+					'orderby'     => 'title',
+					'order'       => 'ASC',
+					'post_type' => 'keel-pets'
+			);
+
+			add_filter( 'posts_where', array($this, 'title_filter'), 10, 2 );
+			$my_query = new WP_Query($args);
+			if ($my_query->have_posts() == true) {
+				while ($my_query->have_posts()) : $my_query->the_post();
+					setup_postdata($post);
+					$fpw_queried_id = get_the_ID();
+				endwhile;
+			} else {
+				$args['search_pet_title'] = $this->featured_pet_backup;
+				$this->featured_pet = $instance['featured_pet_backup'];
+				$my_query = new WP_Query($args);
+				while ($my_query->have_posts()) : $my_query->the_post();
+					setup_postdata($post);
+					$fpw_queried_id = get_the_ID();
+				endwhile;
+			}
+			if ($my_query->have_posts() == false) {
+				unset($args['search_pet_title']);
+				$my_query = new WP_Query($args);
+				while ($my_query->have_posts()) : $my_query->the_post();
+					setup_postdata($post);
+					$fpw_queried_id = get_the_ID();
+				endwhile;
+			}
+			remove_filter( 'posts_where', array($this, 'title_filter'), 10, 2 );
+
+			wp_reset_postdata();
+
+				$fpw_args = array(
+					'posts_per_page' => 1,
+					'p' => $fpw_queried_id,
+					'post_type' => 'keel-pets',
+					'order' => 'ASC'
+				);
+
+			/* Generate Featured Pet Display */
+
+			$fpw_posts = new WP_Query($fpw_args);
+
+			while ($fpw_posts->have_posts()) :
+
+				$fpw_posts->the_post();
+
+				setup_postdata($post);
+
+		// Variables
+		$options = keel_pet_listings_get_theme_options(); // Pet Listings options
+		$details = get_post_meta( $post->ID, 'keel_pet_listings_pet_details', true ); // Details for this pet
+		
+		if ($type == "full"):
+			$img = get_post_meta( $post->ID, 'keel_pet_listings_pet_imgs', true ); // All Images for this pet
+		else:
+			$img = get_post_meta( $post->ID, 'keel_pet_listings_single_img', true ); // Single Image
+		endif;
+		
+		$return = '<article class="container">';
+
+		$return .= '<h2 class="featured-pet-name">' . '<a class="keel-featured-pet" href="'.get_the_permalink().'">' .
+								get_the_title() . '</a></h2>';
+
+				// Pet image
+				if ( !empty( $img ) ) {
+					if ($type == "full"):
+						$return .= $img;
+					else:
+						$return .= '<a class="keel-featured-pet" href="'.get_the_permalink().'">'.$img.'</a>';
+					endif;
+				}
+		
+				// Key pet info
+			$return .= '<ul class="list-unstyled">' .
+				'<li><strong>' . __( 'Size', 'keel' ) . '</strong> ' . esc_attr( $details['size'] ) .'</li>' .
+				'<li><strong>' . __( 'Age', 'keel' ) . '</strong> ' . esc_attr( $details['age'] ) .'</li>' .
+				'<li><strong>' . __( 'Gender', 'keel' ) . '</strong> ' . esc_attr( $details['gender'] ) .'</li>' .
+				'<li><strong>' . __( 'Breeds', 'keel' ) . '</strong> ' . esc_attr( $details['breeds'] ) .'</li>';
+				if(!empty( $details['options']['multi'] ))
+					$return .= '<li><em>' . esc_attr( $details['options']['multi'] ) . '</em></li>';
+				if (!empty( $details['options']['special_needs'] ))
+					$return .= '<li><em>' . esc_attr( $details['options']['special_needs'] ) . '</em></li>' .
+			$return .= '</ul>';
+
+				// The page or post content
+				$return .= get_the_excerpt();
+
+				$return .= '</article>';
+
+			endwhile;
+			
+			// Restore original Post Data
+			wp_reset_postdata();
+						
+			return $return;
+
+		}
+		
+		// Changing excerpt more
+    function featured_pet_excerpt_more($more) {
+    	global $post;
+    	return '… <a href="'. get_permalink($post->ID) . '">' . 'learn more &raquo;' . '</a>';
+    }
+    
+    
+		function title_filter( $where, &$wp_query )
+			{
+					global $wpdb;
+					if ( $search_term = $wp_query->get( 'search_pet_title' ) ) {
+							$where .= ' AND ' . $wpdb->posts . '.post_title = \'' . esc_sql( $this->featured_pet ) . '\'';
+					}
+					return $where;
+			}
+		
+	} // End Featured_Pet object
+	
+	$featured_pet = new Featured_Pet();
+	add_shortcode( 'featured-pet', array($featured_pet,'keel_featured_pet_shortcode') );
+	add_filter('excerpt_more', array($featured_pet, 'featured_pet_excerpt_more'));
+	


### PR DESCRIPTION
Since $post->IDs are changing it records and returns Title, so if there are pets with matching names may not get the right one. Could probably use Title concat with some Meta info like breed to prevent this happening, but it seems to be working fairly well. I could make it a separate plugin, but think it fits fairly well in with the theme.
